### PR TITLE
Fix bug in cairo_jpg.c to use full stream content for image surface creation

### DIFF
--- a/src/cairo_jpg.c
+++ b/src/cairo_jpg.c
@@ -450,6 +450,10 @@ cairo_surface_t *cairo_image_surface_create_from_jpeg_stream(cairo_read_func_t r
       // check for error
       if (rlen == CAIRO_STATUS_READ_ERROR)
          eof++;
+
+      // manually increase read length because cairo_read_func_t
+      // does not return the actual number of bytes read
+      rlen = CAIRO_JPEG_IO_BLOCK_SIZE;
 #endif
    }
 

--- a/src/php_cairo_internal.h
+++ b/src/php_cairo_internal.h
@@ -155,7 +155,7 @@ extern cairo_surface_object *cairo_surface_fetch_object(zend_object *object);
 extern zend_object* cairo_surface_create_object(zend_class_entry *ce);
 extern cairo_surface_object *cairo_surface_object_get(zval *zv);
 extern cairo_status_t php_cairo_write_func(void *closure, const unsigned char *data, unsigned int length);
-extern cairo_status_t php_cairo_read_func(void *closure, const unsigned char *data, unsigned int length);
+extern cairo_status_t php_cairo_read_func(void *closure, unsigned char *data, unsigned int length);
 
 /* Font + FontFace */
 typedef struct _cairo_font_face_object {

--- a/src/php_cairo_internal.h
+++ b/src/php_cairo_internal.h
@@ -155,7 +155,7 @@ extern cairo_surface_object *cairo_surface_fetch_object(zend_object *object);
 extern zend_object* cairo_surface_create_object(zend_class_entry *ce);
 extern cairo_surface_object *cairo_surface_object_get(zval *zv);
 extern cairo_status_t php_cairo_write_func(void *closure, const unsigned char *data, unsigned int length);
-extern cairo_status_t php_cairo_read_func(void *closure, unsigned char *data, unsigned int length);
+extern cairo_status_t php_cairo_read_func(void *closure, const unsigned char *data, unsigned int length);
 
 /* Font + FontFace */
 typedef struct _cairo_font_face_object {

--- a/src/surface.c
+++ b/src/surface.c
@@ -803,45 +803,24 @@ cairo_status_t php_cairo_write_func(void *closure, const unsigned char *data, un
     written = php_stream_write(cast_closure->stream, data, length);
     if (written == length) {
         return CAIRO_STATUS_SUCCESS;
-    } else {
-        return CAIRO_STATUS_WRITE_ERROR;
     }
+
+    return CAIRO_STATUS_WRITE_ERROR;
 }
 
-cairo_status_t php_cairo_read_func(void *closure, unsigned char *data, unsigned int length)
+cairo_status_t php_cairo_read_func(void *closure, const unsigned char *data, unsigned int length)
 {
     unsigned int read;
     stream_closure *cast_closure;
 
     cast_closure = (stream_closure *)closure;
 
-    fprintf(stderr, "DEBUG: Attempting to read %u bytes\n", length);
-
-    if (php_stream_eof(cast_closure->stream)) {
-        fprintf(stderr, "DEBUG: Stream is at EOF before read\n");
-        return CAIRO_STATUS_READ_ERROR;
-    }
-
     read = php_stream_read(cast_closure->stream, (char *)data, length);
-
-    fprintf(stderr, "DEBUG: Read %u bytes (requested %u)\n", read, length);
-    if (read > 0 && read <= length) {
-        fprintf(stderr, "DEBUG: First few bytes read: ");
-        for (int i = 0; i < (read < 8 ? read : 8); i++) {
-            fprintf(stderr, "0x%02x ", data[i]);
-        }
-        fprintf(stderr, "\n");
-    }
-
     if (read == length) {
         return CAIRO_STATUS_SUCCESS;
-    } else if (read == 0 && php_stream_eof(cast_closure->stream)) {
-        // At EOF - this is normal, not an error
-        return CAIRO_STATUS_SUCCESS;  // or maybe return a special EOF status if Cairo has one
-    } else {
-        fprintf(stderr, "DEBUG: Read error - got %u bytes, expected %u\n", read, length);
-        return CAIRO_STATUS_READ_ERROR;
     }
+
+    return CAIRO_STATUS_READ_ERROR;
 }
 
 zend_class_entry* php_cairo_get_surface_ce(cairo_surface_t *surface)

--- a/src/surface.c
+++ b/src/surface.c
@@ -808,17 +808,38 @@ cairo_status_t php_cairo_write_func(void *closure, const unsigned char *data, un
     }
 }
 
-cairo_status_t php_cairo_read_func(void *closure, const unsigned char *data, unsigned int length)
+cairo_status_t php_cairo_read_func(void *closure, unsigned char *data, unsigned int length)
 {
     unsigned int read;
     stream_closure *cast_closure;
 
     cast_closure = (stream_closure *)closure;
 
+    fprintf(stderr, "DEBUG: Attempting to read %u bytes\n", length);
+
+    if (php_stream_eof(cast_closure->stream)) {
+        fprintf(stderr, "DEBUG: Stream is at EOF before read\n");
+        return CAIRO_STATUS_READ_ERROR;
+    }
+
     read = php_stream_read(cast_closure->stream, (char *)data, length);
+
+    fprintf(stderr, "DEBUG: Read %u bytes (requested %u)\n", read, length);
+    if (read > 0 && read <= length) {
+        fprintf(stderr, "DEBUG: First few bytes read: ");
+        for (int i = 0; i < (read < 8 ? read : 8); i++) {
+            fprintf(stderr, "0x%02x ", data[i]);
+        }
+        fprintf(stderr, "\n");
+    }
+
     if (read == length) {
         return CAIRO_STATUS_SUCCESS;
+    } else if (read == 0 && php_stream_eof(cast_closure->stream)) {
+        // At EOF - this is normal, not an error
+        return CAIRO_STATUS_SUCCESS;  // or maybe return a special EOF status if Cairo has one
     } else {
+        fprintf(stderr, "DEBUG: Read error - got %u bytes, expected %u\n", read, length);
         return CAIRO_STATUS_READ_ERROR;
     }
 }

--- a/tests/CairoSurface/CairoImageSurface/createFromJpeg.phpt
+++ b/tests/CairoSurface/CairoImageSurface/createFromJpeg.phpt
@@ -12,6 +12,19 @@ var_dump($surface);
 
 echo dirname(__FILE__) . '/red.jpg' . PHP_EOL;
 $resource = fopen(dirname(__FILE__) . '/red.jpg', 'rb');
+
+echo "Stream position: " . ftell($resource) . "\n";
+echo "EOF: " . (feof($resource) ? 'true' : 'false') . "\n";
+
+$test_bytes = fread($resource, 8);
+echo "First 8 bytes: ";
+for ($i = 0; $i < strlen($test_bytes); $i++) {
+    printf("0x%02x ", ord($test_bytes[$i]));
+}
+echo "\n";
+
+
+rewind($resource);
 $surface = Cairo\Surface\Image::createFromJpeg($resource);
 var_dump($surface);
 fclose($resource);

--- a/tests/CairoSurface/CairoImageSurface/createFromJpeg.phpt
+++ b/tests/CairoSurface/CairoImageSurface/createFromJpeg.phpt
@@ -10,21 +10,7 @@ if (!in_array('JPEG', Cairo\Cairo::availableSurfaces()))
 $surface = Cairo\Surface\Image::createFromJpeg(dirname(__FILE__) . '/red.jpg');
 var_dump($surface);
 
-echo dirname(__FILE__) . '/red.jpg' . PHP_EOL;
 $resource = fopen(dirname(__FILE__) . '/red.jpg', 'rb');
-
-echo "Stream position: " . ftell($resource) . "\n";
-echo "EOF: " . (feof($resource) ? 'true' : 'false') . "\n";
-
-$test_bytes = fread($resource, 8);
-echo "First 8 bytes: ";
-for ($i = 0; $i < strlen($test_bytes); $i++) {
-    printf("0x%02x ", ord($test_bytes[$i]));
-}
-echo "\n";
-
-
-rewind($resource);
 $surface = Cairo\Surface\Image::createFromJpeg($resource);
 var_dump($surface);
 fclose($resource);


### PR DESCRIPTION
closes #3

compare to https://github.com/rahra/cairo_jpg/issues/8