### PR TITLE
Rectangles class backed by floats replaces int based class

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -1162,7 +1162,9 @@ PHP_METHOD(Cairo_Context, getClipRectangleList)
 {
     cairo_context_object *context_object;
     cairo_rectangle_list_t *rectangles;
-    zval new_array;
+    cairo_rectangle_t rectangle;
+    zval rectangle_zv;
+    cairo_rectangle_object *rectangle_object;
     int i;
 
     ZEND_PARSE_PARAMETERS_NONE();
@@ -1177,21 +1179,18 @@ PHP_METHOD(Cairo_Context, getClipRectangleList)
         RETURN_THROWS();
     }
 
-    /* walk our rectangles, create array, push it onto return */
     array_init(return_value);
 
     for (i = 0; i < rectangles->num_rectangles; i++) {
-        cairo_rectangle_t rectangle = rectangles->rectangles[i];
+        rectangle = rectangles->rectangles[i];
 
-        array_init(&new_array);
-        add_assoc_double(&new_array, "x", rectangle.x);
-        add_assoc_double(&new_array, "y", rectangle.y);
-        add_assoc_double(&new_array, "width", rectangle.width);
-        add_assoc_double(&new_array, "height", rectangle.height);
-        add_next_index_zval(return_value, &new_array);
+        object_init_ex(&rectangle_zv, php_cairo_get_rectangle_ce());
+        rectangle_object = Z_CAIRO_RECTANGLE_P(&rectangle_zv);
+        *rectangle_object->rect = rectangle;
+
+        add_next_index_zval(return_value, &rectangle_zv);
     }
 
-    /* don't forget to clean up */
     cairo_rectangle_list_destroy(rectangles);
 }
 /* }}} */

--- a/src/context.stub.php
+++ b/src/context.stub.php
@@ -132,7 +132,7 @@ class Context
     public function getClipExtents(): array {}
 
     /**
-     * @return array<array{x: float, y: float, width: float, height: float}>
+     * @return Rectangle[]
      */
     public function getClipRectangleList(): array {}
 

--- a/src/context_arginfo.h
+++ b/src/context_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 89ffe2d5d50c03d379e01a437b041ad059187aee */
+ * Stub hash: 732060a29a00b42f8d33359df4b0d8cec81cdc0e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Cairo_Context___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, surface, Cairo\\Surface, 0)

--- a/src/php_cairo_internal.h
+++ b/src/php_cairo_internal.h
@@ -242,12 +242,12 @@ extern cairo_context_object *cairo_context_fetch_object(zend_object *object);
 
 /* Rectangle */
 typedef struct _cairo_rectangle_object {
-    cairo_rectangle_int_t *rect;
+    cairo_rectangle_t *rect;
     zend_object std;
 } cairo_rectangle_object;
 extern cairo_rectangle_object *cairo_rectangle_fetch_object(zend_object *object);
 #define Z_CAIRO_RECTANGLE_P(zv) cairo_rectangle_fetch_object(Z_OBJ_P(zv))
-extern cairo_rectangle_int_t *cairo_rectangle_object_get_rect(zval *zv);
+extern cairo_rectangle_t *cairo_rectangle_object_get_rect(zval *zv);
 
 /* Glyph */
 typedef struct _cairo_glyph_object {

--- a/src/php_cairo_internal.h
+++ b/src/php_cairo_internal.h
@@ -248,6 +248,8 @@ typedef struct _cairo_rectangle_object {
 extern cairo_rectangle_object *cairo_rectangle_fetch_object(zend_object *object);
 #define Z_CAIRO_RECTANGLE_P(zv) cairo_rectangle_fetch_object(Z_OBJ_P(zv))
 extern cairo_rectangle_t *cairo_rectangle_object_get_rect(zval *zv);
+extern cairo_rectangle_int_t cairo_expand_to_rectangle_int(cairo_rectangle_t *rect);
+extern void cairo_rectangle_int_to_double(cairo_rectangle_int_t *rect_int, cairo_rectangle_t *rect_double);
 
 /* Glyph */
 typedef struct _cairo_glyph_object {

--- a/src/php_cairo_internal.h
+++ b/src/php_cairo_internal.h
@@ -248,7 +248,7 @@ typedef struct _cairo_rectangle_object {
 extern cairo_rectangle_object *cairo_rectangle_fetch_object(zend_object *object);
 #define Z_CAIRO_RECTANGLE_P(zv) cairo_rectangle_fetch_object(Z_OBJ_P(zv))
 extern cairo_rectangle_t *cairo_rectangle_object_get_rect(zval *zv);
-extern cairo_rectangle_int_t cairo_expand_to_rectangle_int(cairo_rectangle_t *rect);
+extern void cairo_expand_to_rectangle_int(cairo_rectangle_t *rect_double, cairo_rectangle_int_t *rect_int);
 extern void cairo_rectangle_int_to_double(cairo_rectangle_int_t *rect_int, cairo_rectangle_t *rect_double);
 
 /* Glyph */

--- a/src/recording_surface.c
+++ b/src/recording_surface.c
@@ -69,32 +69,28 @@ PHP_METHOD(Cairo_Surface_Recording, __construct)
 {
     zval *content;
     cairo_surface_object *surface_object;
-    cairo_rectangle_t *rectangle = NULL;
+    cairo_rectangle_object *rectangle = NULL;
     zval *extents = NULL;
 
     ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_OBJECT_OF_CLASS(content, ce_cairo_content)
         Z_PARAM_OPTIONAL
-        Z_PARAM_ARRAY(extents)
+        Z_PARAM_OBJECT_OF_CLASS_OR_NULL(extents, php_cairo_get_rectangle_ce())
     ZEND_PARSE_PARAMETERS_END();
-
-    if (extents != NULL) {
-        rectangle = php_cairo_make_rectangle(extents);
-    }
 
     surface_object = Z_CAIRO_SURFACE_P(getThis());
     if (!surface_object) {
         RETURN_NULL();
     }
 
+    if (extents != NULL && Z_TYPE_P(extents) == IS_OBJECT) {
+        rectangle = Z_CAIRO_RECTANGLE_P(extents);
+    }
+
     surface_object->surface = cairo_recording_surface_create(
         Z_LVAL_P(zend_enum_fetch_case_value(Z_OBJ_P(content))),
-        rectangle
+        rectangle ? rectangle->rect : NULL
     );
-
-    if (rectangle != NULL) {
-        efree(rectangle);
-    }
 
     if (php_cairo_throw_exception(cairo_surface_status(surface_object->surface))) {
         RETURN_THROWS();
@@ -110,6 +106,7 @@ PHP_METHOD(Cairo_Surface_Recording, __construct)
 PHP_METHOD(Cairo_Surface_Recording, inkExtents)
 {
     cairo_surface_object *surface_object;
+    cairo_rectangle_object *rectangle_object;
     double x, y, width, height;
 
     ZEND_PARSE_PARAMETERS_NONE();
@@ -120,11 +117,13 @@ PHP_METHOD(Cairo_Surface_Recording, inkExtents)
     }
 
     cairo_recording_surface_ink_extents(surface_object->surface, &x, &y, &width, &height);
-    array_init(return_value);
-    add_assoc_double(return_value, "x", x);
-    add_assoc_double(return_value, "y", y);
-    add_assoc_double(return_value, "width", width);
-    add_assoc_double(return_value, "height", height);
+    // TODO: convert to Rectangle object
+    object_init_ex(return_value, php_cairo_get_rectangle_ce());
+    rectangle_object = Z_CAIRO_RECTANGLE_P(return_value);
+    rectangle_object->rect->x = x;
+    rectangle_object->rect->y = y;
+    rectangle_object->rect->width = width;
+    rectangle_object->rect->height = height;
 }
 /* }}} */
 
@@ -149,16 +148,12 @@ PHP_METHOD(Cairo_Surface_Recording, getExtents)
 
     if (cairo_recording_surface_get_extents(surface_object->surface, rectangle) == IS_FALSE) {
         efree(rectangle);
-        //php_cairo_throw_exception(cairo_surface_status(surface_object->surface));
         RETURN_FALSE;
     }
 
     object_init_ex(return_value, php_cairo_get_rectangle_ce());
     rectangle_object = Z_CAIRO_RECTANGLE_P(return_value);
-    rectangle_object->rect->x = rectangle->x;
-    rectangle_object->rect->y = rectangle->y;
-    rectangle_object->rect->width = rectangle->width;
-    rectangle_object->rect->height = rectangle->height;
+    *rectangle_object->rect = *rectangle;
     efree(rectangle);
 }
 /* }}} */

--- a/src/recording_surface.c
+++ b/src/recording_surface.c
@@ -28,37 +28,6 @@
 
 zend_class_entry *ce_cairo_recordingsurface;
 
-static double php_cairo_get_double_from_array(zval *val, const char *name)
-{
-    zval *tmp;
-
-    // zend_string *key = zend_string_init_fast(name, strlen(name));
-    // tmp = zend_hash_find(Z_ARR_P(val), key);
-    tmp = zend_hash_str_find(Z_ARRVAL_P(val), name, strlen(name));
-    if (tmp != NULL) {
-        if (Z_TYPE_P(tmp) != IS_DOUBLE) {
-            convert_to_double(tmp);
-        }
-
-        return Z_DVAL_P(tmp);
-    }
-
-    zend_error(E_WARNING, "Key '%s' does not exist", name);
-
-    return 0;
-}
-
-static cairo_rectangle_t *php_cairo_make_rectangle(zval *val)
-{
-    cairo_rectangle_t *rectangle = ecalloc(1, sizeof(cairo_rectangle_t));
-
-    rectangle->x = php_cairo_get_double_from_array(val, "x");
-    rectangle->y = php_cairo_get_double_from_array(val, "y");
-    rectangle->width = php_cairo_get_double_from_array(val, "width");
-    rectangle->height = php_cairo_get_double_from_array(val, "height");
-    return rectangle;
-}
-
 /* ----------------------------------------------------------------
     Cairo\Surface\Recording Class API
 ------------------------------------------------------------------*/

--- a/src/recording_surface.stub.php
+++ b/src/recording_surface.stub.php
@@ -5,24 +5,16 @@
  * @generate-legacy-arginfo 80100
  */
 
-namespace Cairo\Surface
+namespace Cairo\Surface;
+
+class Recording extends \Cairo\Surface
 {
-    class Recording extends \Cairo\Surface
-    {
-        /**
-         * @param Content $content
-         * @param null|array{x: float, y: float, width: float, height: float} $extends
-         */
-        public function __construct(
-            Content $content,
-            null|array $extents = null
-        ) {}
+    public function __construct(
+        Content $content,
+        null|\Cairo\Rectangle $extents = null
+    ) {}
 
-        /**
-         * @return array{x: float, y: float, width: float, height: float}
-         */
-        public function inkExtents(): array {}
+    public function inkExtents(): \Cairo\Rectangle {}
 
-        public function getExtents(): \Cairo\Rectangle|false {}
-    }
+    public function getExtents(): \Cairo\Rectangle|false {}
 }

--- a/src/recording_surface_arginfo.h
+++ b/src/recording_surface_arginfo.h
@@ -1,12 +1,12 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 33221dc75e06d64e9caa302e83c12665bebf9cb2 */
+ * Stub hash: 183583230876da13f92f7de792d3e0439b01837b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Cairo_Surface_Recording___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, content, Cairo\\Surface\\Content, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, extents, IS_ARRAY, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, extents, Cairo\\Rectangle, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Cairo_Surface_Recording_inkExtents, 0, 0, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Cairo_Surface_Recording_inkExtents, 0, 0, Cairo\\Rectangle, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Cairo_Surface_Recording_getExtents, 0, 0, Cairo\\Rectangle, MAY_BE_FALSE)

--- a/src/rectangle.c
+++ b/src/rectangle.c
@@ -100,6 +100,37 @@ zend_class_entry* php_cairo_get_rectangle_ce()
     return ce_cairo_rectangle;
 }
 
+cairo_rectangle_int_t cairo_expand_to_rectangle_int(cairo_rectangle_t *rect) {
+    cairo_rectangle_int_t result;
+
+    // Expand rectangle to contain all fractional parts
+    double x0 = rect->x;
+    double y0 = rect->y;
+    double x1 = rect->x + rect->width;
+    double y1 = rect->y + rect->height;
+
+    // expand outward
+    result.x = (int) floor(x0);
+    result.y = (int) floor(y0);
+
+    // Ceiling for right/bottom, then calculate width/height
+    int new_x1 = (int) ceil(x1);
+    int new_y1 = (int) ceil(y1);
+
+    result.width = new_x1 - result.x;
+    result.height = new_y1 - result.y;
+
+    return result;
+}
+
+void cairo_rectangle_int_to_double(cairo_rectangle_int_t *rect_int, cairo_rectangle_t *rect_double) {
+    rect_double->x = (double) rect_int->x;
+    rect_double->y = (double) rect_int->y;
+    rect_double->width = (double) rect_int->width;
+    rect_double->height = (double) rect_int->height;
+}
+
+
 /* ----------------------------------------------------------------
     \Cairo\Rectangle Class API
 ------------------------------------------------------------------*/

--- a/src/rectangle.c
+++ b/src/rectangle.c
@@ -100,27 +100,28 @@ zend_class_entry* php_cairo_get_rectangle_ce()
     return ce_cairo_rectangle;
 }
 
-cairo_rectangle_int_t cairo_expand_to_rectangle_int(cairo_rectangle_t *rect) {
-    cairo_rectangle_int_t result;
+void cairo_expand_to_rectangle_int(cairo_rectangle_t *rect_double, cairo_rectangle_int_t *rect_int) {
+    if (rect_double == NULL) {
+        rect_int = NULL;
+        return;
+    }
 
     // Expand rectangle to contain all fractional parts
-    double x0 = rect->x;
-    double y0 = rect->y;
-    double x1 = rect->x + rect->width;
-    double y1 = rect->y + rect->height;
+    double x0 = rect_double->x;
+    double y0 = rect_double->y;
+    double x1 = rect_double->x + rect_double->width;
+    double y1 = rect_double->y + rect_double->height;
 
     // expand outward
-    result.x = (int) floor(x0);
-    result.y = (int) floor(y0);
+    rect_int->x = (int) floor(x0);
+    rect_int->y = (int) floor(y0);
 
     // Ceiling for right/bottom, then calculate width/height
     int new_x1 = (int) ceil(x1);
     int new_y1 = (int) ceil(y1);
 
-    result.width = new_x1 - result.x;
-    result.height = new_y1 - result.y;
-
-    return result;
+    rect_int->width = new_x1 - rect_int->x;
+    rect_int->height = new_y1 - rect_int->y;
 }
 
 void cairo_rectangle_int_to_double(cairo_rectangle_int_t *rect_int, cairo_rectangle_t *rect_double) {

--- a/src/rectangle.c
+++ b/src/rectangle.c
@@ -125,6 +125,11 @@ void cairo_expand_to_rectangle_int(cairo_rectangle_t *rect_double, cairo_rectang
 }
 
 void cairo_rectangle_int_to_double(cairo_rectangle_int_t *rect_int, cairo_rectangle_t *rect_double) {
+    if (rect_int == NULL) {
+        rect_double = NULL;
+        return;
+    }
+
     rect_double->x = (double) rect_int->x;
     rect_double->y = (double) rect_int->y;
     rect_double->width = (double) rect_int->width;

--- a/src/rectangle.c
+++ b/src/rectangle.c
@@ -33,16 +33,16 @@ cairo_rectangle_object *cairo_rectangle_fetch_object(zend_object *object)
     return (cairo_rectangle_object *) ((char*)(object) - XtOffsetOf(cairo_rectangle_object, std));
 }
 
-static inline long cairo_rectangle_get_property_default(zend_class_entry *ce, char * name) {
+static inline double cairo_rectangle_get_property_default(zend_class_entry *ce, char * name) {
     zend_property_info *property_info;
-    long value = 0;
+    double value = 0;
     zend_string *key = zend_string_init(name, strlen(name), 0);
 
     property_info = zend_get_property_info(ce, key, 1);
     if (property_info) {
         zval *val = (zval*)((char*)ce->default_properties_table + property_info->offset - OBJ_PROP_TO_OFFSET(0));
         if (val) {
-            value = zval_get_long(val);
+            value = zval_get_double(val);
         }
     }
     zend_string_release(key);
@@ -53,11 +53,11 @@ static inline long cairo_rectangle_get_property_value(zend_object *object, char 
     zval *prop, rv;
 
     prop = zend_read_property(object->ce, object, name, strlen(name), 1, &rv);
-    return zval_get_long(prop);
+    return zval_get_double(prop);
 }
 
 #define CAIRO_ALLOC_RECT(rect_value) if (!rect_value) \
-    { rect_value = ecalloc(1, sizeof(cairo_rectangle_int_t)); }
+    { rect_value = ecalloc(1, sizeof(cairo_rectangle_t)); }
 
 #define CAIRO_VALUE_FROM_STRUCT(n) \
     if (strcmp(member->val, #n) == 0) { \
@@ -67,12 +67,12 @@ static inline long cairo_rectangle_get_property_value(zend_object *object, char 
 
 #define CAIRO_VALUE_TO_STRUCT(n) \
     if (strcmp(member->val, #n) == 0) { \
-        rectangle_object->rect->n = zval_get_long(value); \
+        rectangle_object->rect->n = zval_get_double(value); \
         break; \
     }
 
 #define CAIRO_ADD_STRUCT_VALUE(n) \
-    ZVAL_LONG(&tmp, rectangle_object->rect->n); \
+    ZVAL_DOUBLE(&tmp, rectangle_object->rect->n); \
     zend_hash_str_update(props, #n, sizeof(#n)-1, &tmp);
 
 /* ----------------------------------------------------------------
@@ -80,7 +80,7 @@ static inline long cairo_rectangle_get_property_value(zend_object *object, char 
 ------------------------------------------------------------------*/
 
 /* {{{ */
-cairo_rectangle_int_t *cairo_rectangle_object_get_rect(zval *zv)
+cairo_rectangle_t *cairo_rectangle_object_get_rect(zval *zv)
 {
     cairo_rectangle_object *rect_object = Z_CAIRO_RECTANGLE_P(zv);
 
@@ -112,18 +112,18 @@ PHP_METHOD(Cairo_Rectangle, __construct)
     zend_object *object = Z_OBJ_P(getThis());
 
     /* read defaults from object */
-    long x = cairo_rectangle_get_property_value(object, "x");
-    long y = cairo_rectangle_get_property_value(object, "y");
-    long width = cairo_rectangle_get_property_value(object, "width");
-    long height = cairo_rectangle_get_property_value(object, "height");
+    double x = cairo_rectangle_get_property_value(object, "x");
+    double y = cairo_rectangle_get_property_value(object, "y");
+    double width = cairo_rectangle_get_property_value(object, "width");
+    double height = cairo_rectangle_get_property_value(object, "height");
 
     /* Now allow constructor to overwrite them if desired */
     ZEND_PARSE_PARAMETERS_START(0, 4)
         Z_PARAM_OPTIONAL
-        Z_PARAM_LONG(x)
-        Z_PARAM_LONG(y)
-        Z_PARAM_LONG(width)
-        Z_PARAM_LONG(height)
+        Z_PARAM_DOUBLE(x)
+        Z_PARAM_DOUBLE(y)
+        Z_PARAM_DOUBLE(width)
+        Z_PARAM_DOUBLE(height)
     ZEND_PARSE_PARAMETERS_END();
 
     rectangle_object = cairo_rectangle_fetch_object(object);
@@ -199,10 +199,7 @@ static zend_object* cairo_rectangle_clone_obj(zend_object *zobj)
     zend_object *return_value = cairo_rectangle_obj_ctor(zobj->ce, &new_rectangle);
     CAIRO_ALLOC_RECT(new_rectangle->rect);
 
-    new_rectangle->rect->x = old_rectangle->rect->x;
-    new_rectangle->rect->y = old_rectangle->rect->y;
-    new_rectangle->rect->width = old_rectangle->rect->width;
-    new_rectangle->rect->height = old_rectangle->rect->height;
+    *new_rectangle->rect = *old_rectangle->rect;
 
     zend_objects_clone_members(&new_rectangle->std, &old_rectangle->std);
 
@@ -234,7 +231,7 @@ static zval *cairo_rectangle_object_read_property(zend_object *object, zend_stri
     } while(0);
 
     retval = rv;
-    ZVAL_LONG(retval, value);
+    ZVAL_DOUBLE(retval, value);
 
     return retval;
 }

--- a/src/rectangle.stub.php
+++ b/src/rectangle.stub.php
@@ -11,18 +11,18 @@ namespace Cairo;
 // Todo: Make class final
 class Rectangle
 {
-    public int $x = 0;
+    public float $x = 0;
 
-    public int $y = 0;
+    public float $y = 0;
 
-    public int $width = 0;
+    public float $width = 0;
 
-    public int $height = 0;
+    public float $height = 0;
 
     public function __construct(
-        int $x = 0,
-        int $y = 0,
-        int $width = 0,
-        int $height = 0,
+        float $x = 0,
+        float $y = 0,
+        float $width = 0,
+        float $height = 0,
     ) {}
 }

--- a/src/rectangle_arginfo.h
+++ b/src/rectangle_arginfo.h
@@ -1,11 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0bed5a4a3c595bcbe15edbfcc4676ae7a24bae61 */
+ * Stub hash: 712e7fe097074812a47bc4c96697f1f1a12f2cf3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Cairo_Rectangle___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, x, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, y, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, width, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, height, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, x, IS_DOUBLE, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, y, IS_DOUBLE, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, width, IS_DOUBLE, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, height, IS_DOUBLE, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Cairo_Rectangle, __construct);
@@ -29,25 +29,25 @@ static zend_class_entry *register_class_Cairo_Rectangle(void)
 	zval property_x_default_value;
 	ZVAL_LONG(&property_x_default_value, 0);
 	zend_string *property_x_name = zend_string_init("x", sizeof("x") - 1, 1);
-	zend_declare_typed_property(class_entry, property_x_name, &property_x_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_declare_typed_property(class_entry, property_x_name, &property_x_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release(property_x_name);
 
 	zval property_y_default_value;
 	ZVAL_LONG(&property_y_default_value, 0);
 	zend_string *property_y_name = zend_string_init("y", sizeof("y") - 1, 1);
-	zend_declare_typed_property(class_entry, property_y_name, &property_y_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_declare_typed_property(class_entry, property_y_name, &property_y_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release(property_y_name);
 
 	zval property_width_default_value;
 	ZVAL_LONG(&property_width_default_value, 0);
 	zend_string *property_width_name = zend_string_init("width", sizeof("width") - 1, 1);
-	zend_declare_typed_property(class_entry, property_width_name, &property_width_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_declare_typed_property(class_entry, property_width_name, &property_width_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release(property_width_name);
 
 	zval property_height_default_value;
 	ZVAL_LONG(&property_height_default_value, 0);
 	zend_string *property_height_name = zend_string_init("height", sizeof("height") - 1, 1);
-	zend_declare_typed_property(class_entry, property_height_name, &property_height_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_declare_typed_property(class_entry, property_height_name, &property_height_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
 	zend_string_release(property_height_name);
 
 	return class_entry;

--- a/src/region.c
+++ b/src/region.c
@@ -149,7 +149,7 @@ PHP_METHOD(Cairo_Region, __construct)
         region_object->region = cairo_region_create();
     } else if (Z_TYPE_P(rectangles_zval) == IS_OBJECT) {
         rectangle = cairo_rectangle_object_get_rect(rectangles_zval);
-        int_rect = cairo_expand_to_rectangle_int(rectangle);
+        cairo_expand_to_rectangle_int(rectangle, &int_rect);
         region_object->region = cairo_region_create_rectangle(&int_rect);
     } else if (Z_TYPE_P(rectangles_zval) == IS_ARRAY) {
 
@@ -165,7 +165,8 @@ PHP_METHOD(Cairo_Region, __construct)
                 efree(rectangles_array);
                 RETURN_THROWS();
             }
-            rectangles_array[i++] = cairo_expand_to_rectangle_int(cairo_rectangle_object_get_rect(pzval));
+            cairo_expand_to_rectangle_int(cairo_rectangle_object_get_rect(pzval), &int_rect);
+            rectangles_array[i++] = int_rect;
         } ZEND_HASH_FOREACH_END();
 
         region_object->region = cairo_region_create_rectangles(rectangles_array, i);
@@ -342,7 +343,7 @@ PHP_METHOD(Cairo_Region, containsRectangle)
         RETURN_NULL();
     }
 
-    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+    cairo_expand_to_rectangle_int(rectangle_object->rect, &int_rect);
 
     region_overlap_case = php_enum_from_cairo_c_enum(
         ce_cairo_region_overlap,
@@ -458,7 +459,7 @@ PHP_METHOD(Cairo_Region, intersectRectangle)
         RETURN_NULL();
     }
 
-    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+    cairo_expand_to_rectangle_int(rectangle_object->rect, &int_rect);
 
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
@@ -525,7 +526,7 @@ PHP_METHOD(Cairo_Region, subtractRectangle)
         RETURN_NULL();
     }
 
-    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+    cairo_expand_to_rectangle_int(rectangle_object->rect, &int_rect);
 
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
@@ -592,7 +593,7 @@ PHP_METHOD(Cairo_Region, unionRectangle)
         RETURN_NULL();
     }
 
-    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+    cairo_expand_to_rectangle_int(rectangle_object->rect, &int_rect);
 
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
@@ -661,7 +662,7 @@ PHP_METHOD(Cairo_Region, xorRectangle)
         RETURN_NULL();
     }
 
-    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+    cairo_expand_to_rectangle_int(rectangle_object->rect, &int_rect);
 
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,

--- a/src/region.c
+++ b/src/region.c
@@ -129,7 +129,9 @@ PHP_METHOD(Cairo_Region, __construct)
     zval *rectangles_zval = NULL;
     long num_rectangles = 0;
     HashTable *rectangles_hash;
-    cairo_rectangle_int_t *rectangle, *rectangles_array;
+    cairo_rectangle_t *rectangle;
+    cairo_rectangle_int_t *rectangles_array;
+    cairo_rectangle_int_t int_rect;
     int i = 0;
     zval *pzval;
 
@@ -147,7 +149,8 @@ PHP_METHOD(Cairo_Region, __construct)
         region_object->region = cairo_region_create();
     } else if (Z_TYPE_P(rectangles_zval) == IS_OBJECT) {
         rectangle = cairo_rectangle_object_get_rect(rectangles_zval);
-        region_object->region = cairo_region_create_rectangle(rectangle);
+        int_rect = cairo_expand_to_rectangle_int(rectangle);
+        region_object->region = cairo_region_create_rectangle(&int_rect);
     } else if (Z_TYPE_P(rectangles_zval) == IS_ARRAY) {
 
         /* Grab the zend hash and see how big our array will be */
@@ -162,7 +165,7 @@ PHP_METHOD(Cairo_Region, __construct)
                 efree(rectangles_array);
                 RETURN_THROWS();
             }
-            rectangles_array[i++] = *(cairo_rectangle_object_get_rect(pzval));
+            rectangles_array[i++] = cairo_expand_to_rectangle_int(cairo_rectangle_object_get_rect(pzval));
         } ZEND_HASH_FOREACH_END();
 
         region_object->region = cairo_region_create_rectangles(rectangles_array, i);
@@ -210,6 +213,7 @@ PHP_METHOD(Cairo_Region, getExtents)
 {
     cairo_region_object *region_object;
     cairo_rectangle_object *rectangle_object;
+    cairo_rectangle_int_t *int_rect;
 
     ZEND_PARSE_PARAMETERS_NONE();
 
@@ -218,9 +222,11 @@ PHP_METHOD(Cairo_Region, getExtents)
         RETURN_THROWS();
     }
 
+    cairo_region_get_extents(region_object->region, int_rect);
+
     object_init_ex(return_value, php_cairo_get_rectangle_ce());
     rectangle_object = Z_CAIRO_RECTANGLE_P(return_value);
-    cairo_region_get_extents(region_object->region, rectangle_object->rect);
+    cairo_rectangle_int_to_double(int_rect, rectangle_object->rect);
 }
 /* }}} */
 
@@ -248,6 +254,7 @@ PHP_METHOD(Cairo_Region, getRectangle)
     long rectId;
     cairo_region_object *region_object;
     cairo_rectangle_object *rectangle_object;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_LONG(rectId)
@@ -262,9 +269,11 @@ PHP_METHOD(Cairo_Region, getRectangle)
         RETURN_FALSE;
     }
 
+    cairo_region_get_rectangle(region_object->region, rectId, &int_rect);
+
     object_init_ex(return_value, php_cairo_get_rectangle_ce());
     rectangle_object = Z_CAIRO_RECTANGLE_P(return_value);
-    cairo_region_get_rectangle(region_object->region, rectId, rectangle_object->rect);
+    cairo_rectangle_int_to_double(&int_rect, rectangle_object->rect);
 }
 /* }}} */
 
@@ -317,6 +326,7 @@ PHP_METHOD(Cairo_Region, containsRectangle)
     cairo_region_object *region_object;
     zval *rectangle_zval;
     zval region_overlap_case;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_OBJECT_OF_CLASS(rectangle_zval, ce_cairo_rectangle)
@@ -332,9 +342,11 @@ PHP_METHOD(Cairo_Region, containsRectangle)
         RETURN_NULL();
     }
 
+    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+
     region_overlap_case = php_enum_from_cairo_c_enum(
         ce_cairo_region_overlap,
-        cairo_region_contains_rectangle(region_object->region, rectangle_object->rect)
+        cairo_region_contains_rectangle(region_object->region, &int_rect)
     );
 
     if (Z_TYPE(region_overlap_case) == IS_OBJECT) {
@@ -430,6 +442,7 @@ PHP_METHOD(Cairo_Region, intersectRectangle)
     cairo_region_object *region_object;
     zval *rectangle_zval;
     zval status_case;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_OBJECT_OF_CLASS(rectangle_zval, ce_cairo_rectangle)
@@ -445,9 +458,11 @@ PHP_METHOD(Cairo_Region, intersectRectangle)
         RETURN_NULL();
     }
 
+    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
-        cairo_region_intersect_rectangle(region_object->region, rectangle_object->rect)
+        cairo_region_intersect_rectangle(region_object->region, &int_rect)
     );
 
     if (Z_TYPE(status_case) == IS_OBJECT) {
@@ -494,6 +509,7 @@ PHP_METHOD(Cairo_Region, subtractRectangle)
     cairo_rectangle_object *rectangle_object;
     cairo_region_object *region_object;
     zval status_case;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_OBJECT_OF_CLASS(rectangle_zval, ce_cairo_rectangle)
@@ -509,9 +525,11 @@ PHP_METHOD(Cairo_Region, subtractRectangle)
         RETURN_NULL();
     }
 
+    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
-        cairo_region_subtract_rectangle(region_object->region, rectangle_object->rect)
+        cairo_region_subtract_rectangle(region_object->region, &int_rect)
     );
 
     if (Z_TYPE(status_case) == IS_OBJECT) {
@@ -558,6 +576,7 @@ PHP_METHOD(Cairo_Region, unionRectangle)
     cairo_rectangle_object *rectangle_object;
     cairo_region_object *region_object;
     zval status_case;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_OBJECT_OF_CLASS(rectangle_zval, ce_cairo_rectangle)
@@ -573,9 +592,11 @@ PHP_METHOD(Cairo_Region, unionRectangle)
         RETURN_NULL();
     }
 
+    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
-        cairo_region_union_rectangle(region_object->region, rectangle_object->rect)
+        cairo_region_union_rectangle(region_object->region, &int_rect)
     );
 
     if (Z_TYPE(status_case) == IS_OBJECT) {
@@ -624,6 +645,7 @@ PHP_METHOD(Cairo_Region, xorRectangle)
     cairo_rectangle_object *rectangle_object;
     cairo_region_object *region_object;
     zval status_case;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_OBJECT_OF_CLASS(rectangle_zval, ce_cairo_rectangle)
@@ -639,9 +661,11 @@ PHP_METHOD(Cairo_Region, xorRectangle)
         RETURN_NULL();
     }
 
+    int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+
     status_case = php_enum_from_cairo_c_enum(
         ce_cairo_status,
-        cairo_region_xor_rectangle(region_object->region, rectangle_object->rect)
+        cairo_region_xor_rectangle(region_object->region, &int_rect)
     );
 
     if (Z_TYPE(status_case) == IS_OBJECT) {

--- a/src/region.c
+++ b/src/region.c
@@ -214,7 +214,7 @@ PHP_METHOD(Cairo_Region, getExtents)
 {
     cairo_region_object *region_object;
     cairo_rectangle_object *rectangle_object;
-    cairo_rectangle_int_t *int_rect;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_NONE();
 
@@ -223,11 +223,11 @@ PHP_METHOD(Cairo_Region, getExtents)
         RETURN_THROWS();
     }
 
-    cairo_region_get_extents(region_object->region, int_rect);
+    cairo_region_get_extents(region_object->region, &int_rect);
 
     object_init_ex(return_value, php_cairo_get_rectangle_ce());
     rectangle_object = Z_CAIRO_RECTANGLE_P(return_value);
-    cairo_rectangle_int_to_double(int_rect, rectangle_object->rect);
+    cairo_rectangle_int_to_double(&int_rect, rectangle_object->rect);
 }
 /* }}} */
 

--- a/src/surface.c
+++ b/src/surface.c
@@ -560,7 +560,7 @@ PHP_METHOD(Cairo_Surface, mapToImage)
 
     if (rectangle_zval != NULL && Z_TYPE_P(rectangle_zval) == IS_OBJECT) {
         rectangle_object = Z_CAIRO_RECTANGLE_P(rectangle_zval);
-        int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+        cairo_expand_to_rectangle_int(rectangle_object->rect, &int_rect);
         new_surface = cairo_surface_map_to_image(surface_object->surface, &int_rect);
         cairo_surface_reference(new_surface);
     } else {

--- a/src/surface.c
+++ b/src/surface.c
@@ -546,6 +546,7 @@ PHP_METHOD(Cairo_Surface, mapToImage)
     cairo_surface_t *new_surface;
     zval *rectangle_zval = NULL;
     cairo_rectangle_object *rectangle_object;
+    cairo_rectangle_int_t int_rect;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -559,7 +560,8 @@ PHP_METHOD(Cairo_Surface, mapToImage)
 
     if (rectangle_zval != NULL && Z_TYPE_P(rectangle_zval) == IS_OBJECT) {
         rectangle_object = Z_CAIRO_RECTANGLE_P(rectangle_zval);
-        new_surface = cairo_surface_map_to_image(surface_object->surface, rectangle_object->rect);
+        int_rect = cairo_expand_to_rectangle_int(rectangle_object->rect);
+        new_surface = cairo_surface_map_to_image(surface_object->surface, &int_rect);
         cairo_surface_reference(new_surface);
     } else {
         new_surface = cairo_surface_map_to_image(surface_object->surface, NULL);

--- a/tests/CairoContext/getClipRectangleList.phpt
+++ b/tests/CairoContext/getClipRectangleList.phpt
@@ -25,7 +25,7 @@ object(Cairo\Context)#%d (0) {
 }
 array(1) {
   [0]=>
-  array(4) {
+  object(Cairo\Rectangle)#%d (4) {
     ["x"]=>
     float(0)
     ["y"]=>

--- a/tests/CairoSurface/CairoRecordingSurface/__construct.phpt
+++ b/tests/CairoSurface/CairoRecordingSurface/__construct.phpt
@@ -9,21 +9,23 @@ include __DIR__ . '/skipif.inc';
 $surface = new Cairo\Surface\Recording(\Cairo\Surface\Content::ColorAlpha);
 var_dump($surface);
 
-$extents = ['x' => 0, 'y' => 0, 'width' => 400, 'height' => 400];
-$surface2 = new Cairo\Surface\Recording(\Cairo\Surface\Content::ColorAlpha, $extents);
+$surface2 = new Cairo\Surface\Recording(
+    \Cairo\Surface\Content::ColorAlpha,
+    new Cairo\Rectangle(0, 0, 400, 400)
+);
 var_dump($surface2);
 
 /* Wrong number args - 1 */
 try {
     new Cairo\Surface\Recording();
-} catch (TypeError $e) {
+} catch (ArgumentCountError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 
-/* Wrong number args - 4 */
+/* Wrong number args - 3 */
 try {
-    new Cairo\Surface\Recording(NULL, 1, 1, 1);
-} catch (TypeError $e) {
+    new Cairo\Surface\Recording(NULL, 1, 1);
+} catch (ArgumentCountError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 
@@ -46,6 +48,6 @@ object(Cairo\Surface\Recording)#%d (0) {
 object(Cairo\Surface\Recording)#%d (0) {
 }
 Cairo\Surface\Recording::__construct() expects at least 1 argument, 0 given
-Cairo\Surface\Recording::__construct() expects at most 2 arguments, 4 given
+Cairo\Surface\Recording::__construct() expects at most 2 arguments, 3 given
 Cairo\Surface\Recording::__construct(): Argument #1 ($content) must be of type Cairo\Surface\Content, array given
-Cairo\Surface\Recording::__construct(): Argument #2 ($extents) must be of type array, int given
+Cairo\Surface\Recording::__construct(): Argument #2 ($extents) must be of type ?Cairo\Rectangle, int given

--- a/tests/CairoSurface/CairoRecordingSurface/get_extents.phpt
+++ b/tests/CairoSurface/CairoRecordingSurface/get_extents.phpt
@@ -10,14 +10,16 @@ $surface = new Cairo\Surface\Recording(\Cairo\Surface\Content::ColorAlpha);
 var_dump($surface);
 var_dump($surface->getExtents());
 
-$extents = ['x' => 0, 'y' => 0, 'width' => 400, 'height' => 400];
-$surface2 = new Cairo\Surface\Recording(\Cairo\Surface\Content::ColorAlpha, $extents);
+$surface2 = new Cairo\Surface\Recording(
+  \Cairo\Surface\Content::ColorAlpha,
+  new Cairo\Rectangle(0, 0, 400, 400)
+);
 var_dump($surface2->getExtents());
 
 /* Wrong number args - 1 */
 try {
     $surface2->getExtents(1);
-} catch (TypeError $e) {
+} catch (ArgumentCountError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 --EXPECTF--
@@ -25,22 +27,22 @@ object(Cairo\Surface\Recording)#%d (0) {
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(400)
+  float(400)
   ["height"]=>
-  int(400)
+  float(400)
 }
 Cairo\Surface\Recording::getExtents() expects exactly 0 arguments, 1 given

--- a/tests/CairoSurface/CairoRecordingSurface/ink_extents.phpt
+++ b/tests/CairoSurface/CairoRecordingSurface/ink_extents.phpt
@@ -10,20 +10,22 @@ $surface = new Cairo\Surface\Recording(\Cairo\Surface\Content::ColorAlpha);
 var_dump($surface);
 var_dump($surface->inkExtents());
 
-$extents = ['x' => 0, 'y' => 0, 'width' => 400, 'height' => 400];
-$surface2 = new Cairo\Surface\Recording(\Cairo\Surface\Content::ColorAlpha, $extents);
+$surface2 = new Cairo\Surface\Recording(
+  \Cairo\Surface\Content::ColorAlpha,
+  new Cairo\Rectangle(0, 0, 400, 400)
+);
 var_dump($surface2->inkExtents());
 
 /* Wrong number args - 1 */
 try {
     $surface2->inkExtents(1);
-} catch (TypeError $e) {
+} catch (ArgumentCountError $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 --EXPECTF--
 object(Cairo\Surface\Recording)#%d (0) {
 }
-array(4) {
+object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
   float(0)
   ["y"]=>
@@ -33,7 +35,7 @@ array(4) {
   ["height"]=>
   float(0)
 }
-array(4) {
+object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
   float(0)
   ["y"]=>

--- a/tests/Rectangle/__construct.phpt
+++ b/tests/Rectangle/__construct.phpt
@@ -47,16 +47,16 @@ try {
 --EXPECTF--
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 Cairo\Rectangle::__construct() expects at most 4 arguments, 5 given
-Cairo\Rectangle::__construct(): Argument #1 ($x) must be of type int, array given
-Cairo\Rectangle::__construct(): Argument #2 ($y) must be of type int, array given
-Cairo\Rectangle::__construct(): Argument #3 ($width) must be of type int, array given
-Cairo\Rectangle::__construct(): Argument #4 ($height) must be of type int, array given
+Cairo\Rectangle::__construct(): Argument #1 ($x) must be of type float, array given
+Cairo\Rectangle::__construct(): Argument #2 ($y) must be of type float, array given
+Cairo\Rectangle::__construct(): Argument #3 ($width) must be of type float, array given
+Cairo\Rectangle::__construct(): Argument #4 ($height) must be of type float, array given

--- a/tests/Rectangle/__construct_extend.phpt
+++ b/tests/Rectangle/__construct_extend.phpt
@@ -19,11 +19,11 @@ var_dump($fail);
 --EXPECTF--
 object(Bad)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }

--- a/tests/Rectangle/object_handlers/clone_obj.phpt
+++ b/tests/Rectangle/object_handlers/clone_obj.phpt
@@ -21,7 +21,7 @@ $copy = clone $testing;
 var_dump(get_class($copy));
 var_dump($copy->x);
 --EXPECT--
-int(5)
-int(9)
+float(5)
+float(9)
 string(7) "testing"
-int(6)
+float(6)

--- a/tests/Rectangle/object_handlers/create_destroy.phpt
+++ b/tests/Rectangle/object_handlers/create_destroy.phpt
@@ -11,8 +11,8 @@ $rect = new Rectangle();
 unset($rect);
 
 class neo extends Rectangle{
-    public int $x = 1;
-    public int $y = 2;
+    public float $x = 1;
+    public float $y = 2;
 }
 
 $mr_andersen = new neo();
@@ -20,11 +20,11 @@ var_dump($mr_andersen);
 --EXPECTF--
 object(neo)#%d (4) {
   ["x"]=>
-  int(1)
+  float(1)
   ["y"]=>
-  int(2)
+  float(2)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }

--- a/tests/Rectangle/object_handlers/get_properties.phpt
+++ b/tests/Rectangle/object_handlers/get_properties.phpt
@@ -13,13 +13,13 @@ print_r($rect);
 --EXPECTF--
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(6)
+  float(6)
   ["y"]=>
-  int(5)
+  float(5)
   ["width"]=>
-  int(4)
+  float(4)
   ["height"]=>
-  int(3)
+  float(3)
 }
 Cairo\Rectangle Object
 (

--- a/tests/Rectangle/object_handlers/read_property.phpt
+++ b/tests/Rectangle/object_handlers/read_property.phpt
@@ -14,7 +14,7 @@ var_dump($rect->y);
 var_dump($rect->width);
 var_dump($rect->height);
 --EXPECT--
-int(1)
-int(2)
-int(3)
-int(4)
+float(1)
+float(2)
+float(3)
+float(4)

--- a/tests/Rectangle/object_handlers/write_property.phpt
+++ b/tests/Rectangle/object_handlers/write_property.phpt
@@ -19,8 +19,8 @@ var_dump($rect->y);
 var_dump($rect->width);
 var_dump($rect->height);
 --EXPECT--
-int(1)
-int(2)
-int(3)
-int(4)
+float(1)
+float(2)
+float(3)
+float(4)
 

--- a/tests/Region/get_extents.phpt
+++ b/tests/Region/get_extents.phpt
@@ -27,22 +27,22 @@ object(Cairo\Region)#%d (0) {
 }
 object(Cairo\Rectangle)#2 (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 object(Cairo\Rectangle)#5 (4) {
   ["x"]=>
-  int(1)
+  float(1)
   ["y"]=>
-  int(1)
+  float(1)
   ["width"]=>
-  int(201)
+  float(201)
   ["height"]=>
-  int(201)
+  float(201)
 }
 Cairo\Region::getExtents() expects exactly 0 arguments, 1 given

--- a/tests/Region/get_rectangle.phpt
+++ b/tests/Region/get_rectangle.phpt
@@ -34,36 +34,36 @@ object(Cairo\Region)#%d (0) {
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 object(Cairo\Region)#%d (0) {
 }
 int(3)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(100)
+  float(100)
   ["y"]=>
-  int(100)
+  float(100)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(200)
+  float(200)
   ["y"]=>
-  int(200)
+  float(200)
   ["width"]=>
-  int(200)
+  float(200)
   ["height"]=>
-  int(100)
+  float(100)
 }
 bool(false)
 Cairo\Region::getRectangle(): Argument #1 ($rectId) must be of type int, string given

--- a/tests/Region/intersect.phpt
+++ b/tests/Region/intersect.phpt
@@ -40,45 +40,45 @@ object(Cairo\Region)#%d (0) {
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(1)
+  float(1)
   ["y"]=>
-  int(1)
+  float(1)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(20)
+  float(20)
   ["y"]=>
-  int(20)
+  float(20)
   ["width"]=>
-  int(81)
+  float(81)
   ["height"]=>
-  int(81)
+  float(81)
 }
 int(1)
 Cairo\Region::intersect(): Argument #1 ($region) must be of type Cairo\Region, int given

--- a/tests/Region/intersect_rectangle.phpt
+++ b/tests/Region/intersect_rectangle.phpt
@@ -33,13 +33,13 @@ bool(true)
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(25)
+  float(25)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(25)
+  float(25)
   ["height"]=>
-  int(40)
+  float(40)
 }
 Cairo\Region::intersectRectangle(): Argument #1 ($rectangle) must be of type Cairo\Rectangle, int given
 Cairo\Region::intersectRectangle() expects exactly 1 argument, 2 given

--- a/tests/Region/subtract.phpt
+++ b/tests/Region/subtract.phpt
@@ -40,47 +40,47 @@ object(Cairo\Region)#%d (0) {
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 int(1)
 bool(true)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 bool(true)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(70)
+  float(70)
   ["height"]=>
-  int(100)
+  float(100)
 }
 int(1)
 Cairo\Region::subtract(): Argument #1 ($region) must be of type Cairo\Region, int given

--- a/tests/Region/subtract_rectangle.phpt
+++ b/tests/Region/subtract_rectangle.phpt
@@ -33,13 +33,13 @@ bool(true)
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(15)
+  float(15)
   ["height"]=>
-  int(40)
+  float(40)
 }
 Cairo\Region::subtractRectangle(): Argument #1 ($rectangle) must be of type Cairo\Rectangle, int given
 Cairo\Region::subtractRectangle() expects exactly 1 argument, 2 given

--- a/tests/Region/union.phpt
+++ b/tests/Region/union.phpt
@@ -40,47 +40,47 @@ object(Cairo\Region)#%d (0) {
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 int(1)
 bool(true)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 bool(true)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(110)
+  float(110)
   ["height"]=>
-  int(110)
+  float(110)
 }
 int(2)
 Cairo\Region::union(): Argument #1 ($region) must be of type Cairo\Region, int given

--- a/tests/Region/union_rectangle.phpt
+++ b/tests/Region/union_rectangle.phpt
@@ -38,37 +38,37 @@ object(Cairo\Region)#%d (0) {
 int(0)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 bool(true)
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(10)
+  float(10)
   ["height"]=>
-  int(10)
+  float(10)
 }
 bool(true)
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(20)
+  float(20)
   ["height"]=>
-  int(20)
+  float(20)
 }
 Cairo\Region::unionRectangle(): Argument #1 ($rectangle) must be of type Cairo\Rectangle, int given
 Cairo\Region::unionRectangle() expects exactly 1 argument, 2 given

--- a/tests/Region/xor.phpt
+++ b/tests/Region/xor.phpt
@@ -40,47 +40,47 @@ object(Cairo\Region)#%d (0) {
 }
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 int(1)
 bool(true)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(100)
+  float(100)
   ["height"]=>
-  int(100)
+  float(100)
 }
 bool(true)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(110)
+  float(110)
   ["height"]=>
-  int(110)
+  float(110)
 }
 int(3)
 Cairo\Region::xor(): Argument #1 ($region) must be of type Cairo\Region, int given

--- a/tests/Region/xor_rectangle.phpt
+++ b/tests/Region/xor_rectangle.phpt
@@ -38,37 +38,37 @@ object(Cairo\Region)#%d (0) {
 int(0)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(0)
+  float(0)
   ["y"]=>
-  int(0)
+  float(0)
   ["width"]=>
-  int(0)
+  float(0)
   ["height"]=>
-  int(0)
+  float(0)
 }
 bool(true)
 int(1)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(10)
+  float(10)
   ["y"]=>
-  int(10)
+  float(10)
   ["width"]=>
-  int(10)
+  float(10)
   ["height"]=>
-  int(10)
+  float(10)
 }
 bool(true)
 int(4)
 object(Cairo\Rectangle)#%d (4) {
   ["x"]=>
-  int(5)
+  float(5)
   ["y"]=>
-  int(5)
+  float(5)
   ["width"]=>
-  int(20)
+  float(20)
   ["height"]=>
-  int(20)
+  float(20)
 }
 Cairo\Region::xorRectangle(): Argument #1 ($rectangle) must be of type Cairo\Rectangle, int given
 Cairo\Region::xorRectangle() expects exactly 1 argument, 2 given


### PR DESCRIPTION
`Context::getClipRectangleList()` returns array of `Rectangle`s not array of arrays
`$extents argument of RecordingSurface()` needs `Rectangle` not array
`RecordingSurface::inkExtents()` returns array of `Rectangle`s not array of arrays

Internally two c functions convert between `cairo_rectangle_t` and `cairo_rectangle_int_t`:
```c
void cairo_expand_to_rectangle_int(cairo_rectangle_t *rect_double, cairo_rectangle_int_t *rect_int)
void cairo_rectangle_int_to_double(cairo_rectangle_int_t *rect_int, cairo_rectangle_t *rect_double)
```